### PR TITLE
Add guidebook manipulations to chat command system.

### DIFF
--- a/src/main/java/com/auroali/sanguinisluxuria/common/commands/BloodlustCommand.java
+++ b/src/main/java/com/auroali/sanguinisluxuria/common/commands/BloodlustCommand.java
@@ -12,6 +12,7 @@ public class BloodlustCommand {
         return CommandManager.literal(SanguinisLuxuria.MODID.toLowerCase(Locale.ROOT))
           .requires(ctx -> ctx.hasPermissionLevel(2))
           .then(AbilityCommand.register())
-          .then(ConvertCommand.register());
+          .then(ConvertCommand.register())
+          .then(GuidebookCommand.register());
     }
 }

--- a/src/main/java/com/auroali/sanguinisluxuria/common/commands/GuidebookCommand.java
+++ b/src/main/java/com/auroali/sanguinisluxuria/common/commands/GuidebookCommand.java
@@ -1,0 +1,104 @@
+package com.auroali.sanguinisluxuria.common.commands;
+
+import com.auroali.sanguinisluxuria.SanguinisLuxuria;
+import com.mojang.brigadier.arguments.StringArgumentType;
+import com.mojang.brigadier.builder.LiteralArgumentBuilder;
+import com.mojang.brigadier.suggestion.SuggestionProvider;
+import net.minecraft.advancement.Advancement;
+import net.minecraft.advancement.AdvancementProgress;
+import net.minecraft.command.argument.EntityArgumentType;
+import net.minecraft.network.message.SentMessage;
+import net.minecraft.network.message.SignedMessage;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.command.CommandManager;
+import net.minecraft.server.command.ServerCommandSource;
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.text.Text;
+import net.minecraft.util.Identifier;
+
+import java.util.Collection;
+import java.util.function.Supplier;
+
+public class GuidebookCommand {
+    private static final SuggestionProvider<ServerCommandSource> ADVANCEMENT_SUGGESTIONS = (ctx,builder) -> {
+        MinecraftServer server = ctx.getSource().getServer();
+        for(Advancement adv : server.getAdvancementLoader().getAdvancements()){
+            if (adv.getId().getNamespace().equals(SanguinisLuxuria.MODID)) {
+                builder.suggest(adv.getId().toString());
+            }
+        }
+        return builder.buildFuture();
+    };
+
+    public static LiteralArgumentBuilder<ServerCommandSource> register() {
+        // not quite proud of this indenting scheme...
+        return CommandManager.literal("guidebook")
+            .then(CommandManager.argument("playerTarget", EntityArgumentType.player())
+            .then(CommandManager.literal("grant")
+                .then(
+                    CommandManager.literal("all").executes(ctx -> {
+                        ServerPlayerEntity target = EntityArgumentType.getPlayer(ctx,"playerTarget");
+                        Collection<Advancement> all = ctx.getSource().getServer().getAdvancementLoader().getAdvancements();
+
+                        for (Advancement adv : all) {
+                            if (adv.getId().getNamespace().equals(SanguinisLuxuria.MODID)) {
+                                AdvancementProgress advProg = target.getAdvancementTracker().getProgress(adv);
+                                for (String criterion : advProg.getUnobtainedCriteria()){
+                                    target.getAdvancementTracker().grantCriterion(adv,criterion);
+                                }
+                            }
+                        }
+                        return 0;
+                    })
+                )
+                .then(
+                    CommandManager.argument("entryName",StringArgumentType.greedyString())
+                        .suggests(ADVANCEMENT_SUGGESTIONS)
+                        .executes(ctx -> {
+                        ServerPlayerEntity target = EntityArgumentType.getPlayer(ctx,"playerTarget");
+                        Advancement adv = ctx.getSource().getServer().getAdvancementLoader().get(Identifier.tryParse(StringArgumentType.getString(ctx,"entryName")));
+
+                        AdvancementProgress advProg = target.getAdvancementTracker().getProgress(adv);
+                        for (String criterion : advProg.getUnobtainedCriteria()){
+                            target.getAdvancementTracker().grantCriterion(adv,criterion);
+                        }
+
+                        return 0;
+                    })
+                )
+            )
+            .then(CommandManager.literal("revoke")
+                .then(
+                    CommandManager.literal("all").executes(ctx -> {
+                        ServerPlayerEntity target = EntityArgumentType.getPlayer(ctx,"playerTarget");
+                        Collection<Advancement> all = ctx.getSource().getServer().getAdvancementLoader().getAdvancements();
+
+                        for (Advancement adv : all) {
+                            if (adv.getId().getNamespace().equals(SanguinisLuxuria.MODID)) {
+                                AdvancementProgress advProg = target.getAdvancementTracker().getProgress(adv);
+                                for (String criterion : advProg.getObtainedCriteria()){
+                                    target.getAdvancementTracker().revokeCriterion(adv,criterion);
+                                }
+                            }
+                        }
+                        return 0;
+                    })
+                )
+                .then(
+                  CommandManager.argument("entryName",StringArgumentType.greedyString())
+                    .suggests(ADVANCEMENT_SUGGESTIONS)
+                    .executes(ctx -> {
+                        ServerPlayerEntity target = EntityArgumentType.getPlayer(ctx,"playerTarget");
+                        Advancement adv = ctx.getSource().getServer().getAdvancementLoader().get(Identifier.tryParse(StringArgumentType.getString(ctx,"entryName")));
+
+                        AdvancementProgress advProg = target.getAdvancementTracker().getProgress(adv);
+                        for (String criterion : advProg.getObtainedCriteria()){
+                            target.getAdvancementTracker().revokeCriterion(adv,criterion);
+                        }
+
+                        return 0;
+                    })
+                )
+            ));
+    }
+}


### PR DESCRIPTION
Added `/sanguinisluxuria guidebook <target> <grant|revoke> <all|entry name>`
Complete with autocompletions and Best Practices™.
It works by granting advancements that unlock guidebook entries. The way it's special compared to using `/advancement` command is that `/sanguinisluxuria guidebook @s grant `**`all`** will unlock _all_ guidebook entries, including entries on rituals that `/advancement` will unlock only if executed with `everything` or `only <name>` which feels bothersome to me.
<img width="1919" height="833" alt="image" src="https://github.com/user-attachments/assets/952a1d90-1ccd-4e00-a139-77adf2d1f492" />
<img width="1272" height="762" alt="image" src="https://github.com/user-attachments/assets/0f97c177-e3aa-49be-91a6-63cbe100aa42" />
<img width="1184" height="781" alt="image" src="https://github.com/user-attachments/assets/e5476255-6e70-4e61-a9d9-2662f56d439d" />

By the way, one could argue that this Fixes #4 (but that wasn't really an "issue")